### PR TITLE
Add regex for OTC titles to save as Windows filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules
-*.pdf
+# *.pdf
 /ignore
 .DS_Store
-/client/public/pdf

--- a/api/convertURL.js
+++ b/api/convertURL.js
@@ -4,15 +4,19 @@ const path = require('path');
 
 module.exports = async function convertURL(passedInURL) {
 
-    const browser = await puppeteer.launch();
-    const page = await browser.newPage();
-    await page.goto(passedInURL, {
-      waitUntil: 'networkidle2',
-    });
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.goto(passedInURL, {
+    waitUntil: 'networkidle2',
+  });
 
-  const fileName = await page._frameManager._mainFrame.evaluate(() => document.title);
+  let fileName = await page._frameManager._mainFrame.evaluate(() => document.title);
 
-  const pathToPDF = path.join(__dirname, `pdf/${fileName}.pdf`);
+  const chars = {'\|': '-', ',': ''};
+
+  fileName = fileName.replace(/[\|,]/g, key => chars[key]);
+
+  const pathToPDF = path.join(__dirname, `/pdf/${fileName}.pdf`);
 
   await page.pdf({
     path: pathToPDF,


### PR DESCRIPTION
<title> tags in OTC queries contained pipe and comma characters, which are unsaveable in Windows. 

Regex code added to replace these characters and facilitate savability of PDFs. 

```
 const chars = {'\|': '-', ',': ''};

  fileName = fileName.replace(/[\|,]/g, key => chars[key]);
```

